### PR TITLE
Fixes #31 Sane fields for Events

### DIFF
--- a/src/eestec/portal/content/event.py
+++ b/src/eestec/portal/content/event.py
@@ -7,15 +7,24 @@ from eestec.portal import emails
 from five import grok
 from plone.directives import form, dexterity
 from zope import schema
+from plone.app.textfield import RichText
 from zope.interface.declarations import alsoProvides
 
 
 class IEvent(form.Schema):
     """
     """
+    title = schema.TextLine(
+        title=u'Name',
+        required=True,
+    )
     deadline = schema.Datetime(
         title=u'Deadline',
         description=u'Deadline to apply to this event',
+        required=True,
+    )
+    description = RichText(
+        title=u'Description',
         required=True,
     )
 

--- a/src/eestec/portal/profiles/default/types/eestec.portal.event.xml
+++ b/src/eestec/portal/profiles/default/types/eestec.portal.event.xml
@@ -28,7 +28,6 @@
   <!-- enabled behaviors -->
   <property name="behaviors">
     <element value="plone.app.dexterity.behaviors.metadata.ICategorization" />
-    <element value="plone.app.dexterity.behaviors.metadata.IBasic" />
     <element value="plone.app.content.interfaces.INameFromTitle" />
     <element value="plone.app.versioningbehavior.behaviors.IVersionable" />
   </property>


### PR DESCRIPTION
Probably it will be unnecessary once we use the standar Plone events, but JIC.

Note that I removed the IBasic behavior because our description richtext and I
didn't manage to override the default one.

I also needed to recreate my var folder to apply the changes. Probably there's
a fancier way to do it.
